### PR TITLE
Feat: Timetable upload page

### DIFF
--- a/src/components/Timetable/UploadPage.jsx
+++ b/src/components/Timetable/UploadPage.jsx
@@ -28,6 +28,7 @@ export default function UploadPage() {
       <Typography>OR</Typography>
       <TextField
         id="outlined-input"
+        aria-label="Enter URL"
         label="Enter your calendar URL"
         value={calendarURL}
         onChange={handleChange}

--- a/src/components/Timetable/UploadPage.jsx
+++ b/src/components/Timetable/UploadPage.jsx
@@ -8,15 +8,17 @@ import {
   InputAdornment,
   IconButton,
 } from '@mui/material';
+import PropTypes from 'prop-types';
 import SendIcon from '@mui/icons-material/Send';
 import styles from './UploadPage.module.css';
 
 /**
  * This component can be used to display the upload page for the app after the user has logged in.
  * Users can input their timetable details into this page. Currenly the page is not functional.
+ * This component takes in a function as a prop that should handle the behaviour of a user clicking on the submit button.
  *
  */
-export default function UploadPage() {
+export default function UploadPage({ sendTimetableURL }) {
   const [calendarURL, setcalendarURL] = React.useState('');
   const handleChange = (event) => {
     setcalendarURL(event.target.value);
@@ -35,7 +37,7 @@ export default function UploadPage() {
         InputProps={{
           endAdornment: (
             <InputAdornment position="end">
-              <IconButton edge="end" color="primary" aria-label="submit">
+              <IconButton edge="end" color="primary" aria-label="submit" onClick={sendTimetableURL}>
                 <SendIcon />
               </IconButton>
             </InputAdornment>
@@ -52,3 +54,7 @@ export default function UploadPage() {
     </Stack>
   );
 }
+
+UploadPage.propTypes = {
+  sendTimetableURL: PropTypes.func.isRequired,
+};

--- a/src/components/Timetable/UploadPage.jsx
+++ b/src/components/Timetable/UploadPage.jsx
@@ -8,22 +8,26 @@ import styles from './UploadPage.module.css';
  *
  */
 export default function UploadPage() {
-  const [name, setName] = React.useState('');
+  const [calendarURL, setcalendarURL] = React.useState('');
   const handleChange = (event) => {
-    setName(event.target.value);
+    setcalendarURL(event.target.value);
   };
 
   return (
-    <Stack direction="column" spacing={4} className={styles.title}>
+    <Stack direction="column" spacing={3} className={styles.title}>
       <Button variant="contained">Upload Timetable</Button>
       <Typography>OR</Typography>
       <TextField
         id="outlined-input"
         label="Enter your calendar URL"
-        value={name}
+        value={calendarURL}
         onChange={handleChange}
       />
-      <Link href="https://uoacal.auckland.ac.nz/home" underline="hover">
+      <Link
+        href="https://uoacal.auckland.ac.nz/home"
+        underline="hover"
+        target="_blank"
+        rel="noopener noreferrer">
         <Typography>Download your timetable at https://uoacal.auckland.ac.nz/home</Typography>
       </Link>
     </Stack>

--- a/src/components/Timetable/UploadPage.jsx
+++ b/src/components/Timetable/UploadPage.jsx
@@ -1,5 +1,14 @@
 import React from 'react';
-import { Button, Stack, Typography, TextField, Link } from '@mui/material';
+import {
+  Button,
+  Stack,
+  Typography,
+  TextField,
+  Link,
+  InputAdornment,
+  IconButton,
+} from '@mui/material';
+import SendIcon from '@mui/icons-material/Send';
 import styles from './UploadPage.module.css';
 
 /**
@@ -22,6 +31,15 @@ export default function UploadPage() {
         label="Enter your calendar URL"
         value={calendarURL}
         onChange={handleChange}
+        InputProps={{
+          endAdornment: (
+            <InputAdornment position="end">
+              <IconButton edge="end" color="primary" aria-label="submit">
+                <SendIcon />
+              </IconButton>
+            </InputAdornment>
+          ),
+        }}
       />
       <Link
         href="https://uoacal.auckland.ac.nz/home"

--- a/src/components/Timetable/UploadPage.jsx
+++ b/src/components/Timetable/UploadPage.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Button, Stack, Typography } from '@mui/material';
+import styles from './UploadPage.module.css';
+
+/**
+ * This component can be used to display the upload page for the app after the user has logged in.
+ * Users can input their timetable details into this page. Currenly the page is not functional.
+ *
+ */
+export default function UploadPage() {
+  // Setting the first page as the initial active page.
+
+  return (
+    <Stack direction="column" spacing={2} className={styles.title}>
+      <Button variant="contained">Upload Timetable</Button>
+      <Typography>This is an example component.</Typography>
+    </Stack>
+  );
+}

--- a/src/components/Timetable/UploadPage.jsx
+++ b/src/components/Timetable/UploadPage.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button, Stack, Typography } from '@mui/material';
+import { Button, Stack, Typography, TextField, Link } from '@mui/material';
 import styles from './UploadPage.module.css';
 
 /**
@@ -8,12 +8,24 @@ import styles from './UploadPage.module.css';
  *
  */
 export default function UploadPage() {
-  // Setting the first page as the initial active page.
+  const [name, setName] = React.useState('');
+  const handleChange = (event) => {
+    setName(event.target.value);
+  };
 
   return (
-    <Stack direction="column" spacing={2} className={styles.title}>
+    <Stack direction="column" spacing={4} className={styles.title}>
       <Button variant="contained">Upload Timetable</Button>
-      <Typography>This is an example component.</Typography>
+      <Typography>OR</Typography>
+      <TextField
+        id="outlined-input"
+        label="Enter your calendar URL"
+        value={name}
+        onChange={handleChange}
+      />
+      <Link href="https://uoacal.auckland.ac.nz/home" underline="hover">
+        <Typography>Download your timetable at https://uoacal.auckland.ac.nz/home</Typography>
+      </Link>
     </Stack>
   );
 }

--- a/src/components/Timetable/UploadPage.jsx
+++ b/src/components/Timetable/UploadPage.jsx
@@ -23,6 +23,9 @@ export default function UploadPage({ sendTimetableURL }) {
   const handleChange = (event) => {
     setcalendarURL(event.target.value);
   };
+  const handleSubmit = () => {
+    sendTimetableURL(calendarURL);
+  };
 
   return (
     <Stack direction="column" spacing={3} className={styles.title}>
@@ -37,7 +40,7 @@ export default function UploadPage({ sendTimetableURL }) {
         InputProps={{
           endAdornment: (
             <InputAdornment position="end">
-              <IconButton edge="end" color="primary" aria-label="submit" onClick={sendTimetableURL}>
+              <IconButton edge="end" color="primary" aria-label="submit" onClick={handleSubmit}>
                 <SendIcon />
               </IconButton>
             </InputAdornment>

--- a/src/components/Timetable/UploadPage.module.css
+++ b/src/components/Timetable/UploadPage.module.css
@@ -1,6 +1,5 @@
 .title {
   display: flex;
-  flex-direction: column;
   align-items: center;
   text-align: center;
 }

--- a/src/components/Timetable/UploadPage.module.css
+++ b/src/components/Timetable/UploadPage.module.css
@@ -1,0 +1,6 @@
+.title {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+}

--- a/src/components/Timetable/__tests__/UploadPage.test.jsx
+++ b/src/components/Timetable/__tests__/UploadPage.test.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import UploadPage from '../UploadPage';
+
+describe('On UploadPage render', () => {
+  test('should display upload button text', () => {
+    render(<UploadPage />);
+
+    expect(screen.getByText(/upload timetable/i)).toBeInTheDocument();
+  });
+  test('should display input text field', () => {
+    render(<UploadPage />);
+
+    expect(screen.getByLabelText(/enter url/i)).toBeInTheDocument();
+  });
+  test('should display download link', () => {
+    render(<UploadPage />);
+
+    expect(screen.getByRole(/link/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/Timetable/__tests__/UploadPage.test.jsx
+++ b/src/components/Timetable/__tests__/UploadPage.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-
+import userEvent from '@testing-library/user-event';
 import UploadPage from '../UploadPage';
 
 describe('On UploadPage render', () => {
@@ -18,5 +18,17 @@ describe('On UploadPage render', () => {
     render(<UploadPage />);
 
     expect(screen.getByRole(/link/i)).toBeInTheDocument();
+  });
+});
+
+describe('When submit button clicked on UploadPage', () => {
+  test('should call click handler function', () => {
+    let testCounter = 0;
+    const handleSubmit = () => {
+      testCounter += 1;
+    };
+    render(<UploadPage sendTimetableURL={handleSubmit} />);
+    userEvent.click(screen.getByLabelText('submit'));
+    expect(testCounter).toEqual(1);
   });
 });

--- a/src/components/Timetable/index.js
+++ b/src/components/Timetable/index.js
@@ -1,0 +1,3 @@
+import UploadPage from './UploadPage';
+
+export default UploadPage;

--- a/src/pages/Routes/Routes.jsx
+++ b/src/pages/Routes/Routes.jsx
@@ -1,13 +1,11 @@
 import React from 'react';
 import { Route, Routes as Switch } from 'react-router-dom';
 import Dashboard from '../Dashboard';
-import UploadPage from '../../components/Timetable';
 
 function Routes() {
   return (
     <Switch>
       <Route path="/" element={<Dashboard />} />
-      <Route path="/upload" element={<UploadPage />} />
     </Switch>
   );
 }

--- a/src/pages/Routes/Routes.jsx
+++ b/src/pages/Routes/Routes.jsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import { Route, Routes as Switch } from 'react-router-dom';
 import Dashboard from '../Dashboard';
+import UploadPage from '../../components/Timetable';
 
 function Routes() {
   return (
     <Switch>
       <Route path="/" element={<Dashboard />} />
+      <Route path="/upload" element={<UploadPage />} />
     </Switch>
   );
 }


### PR DESCRIPTION
## Description
This PR resolves issue #17. This PR adds a basic Upload Page component that can be used to render a basic timetable upload page according to the designs on the figma board. The component is currently not fully functional and no styling has been applied as that will be addressed in a later PR. 

Material UI components and layouts have been used where possible to display the different buttons and text. The text field will store the typed text into a state variable inside the component. The link will redirect the user to a site where they can download their calendar file.

## How has this been tested?
The Upload Page component has basic render tests that ensure all necessary components are displayed correctly.

## Screenshots
![image](https://user-images.githubusercontent.com/62319771/158107870-9a7fadb0-011f-4932-af20-685df74c7c97.png)

## Checklist
*(Leave blank if not applicable)*

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
