### PR TITLE
BUG: UploadPage component test warnings

### DIFF
--- a/src/components/Timetable/__tests__/UploadPage.test.jsx
+++ b/src/components/Timetable/__tests__/UploadPage.test.jsx
@@ -5,17 +5,17 @@ import UploadPage from '../UploadPage';
 
 describe('On UploadPage render', () => {
   test('should display upload button text', () => {
-    render(<UploadPage />);
+    render(<UploadPage sendTimetableURL={() => {}} />);
 
     expect(screen.getByText(/upload timetable/i)).toBeInTheDocument();
   });
   test('should display input text field', () => {
-    render(<UploadPage />);
+    render(<UploadPage sendTimetableURL={() => {}} />);
 
     expect(screen.getByLabelText(/enter url/i)).toBeInTheDocument();
   });
   test('should display download link', () => {
-    render(<UploadPage />);
+    render(<UploadPage sendTimetableURL={() => {}} />);
 
     expect(screen.getByRole(/link/i)).toBeInTheDocument();
   });


### PR DESCRIPTION
## Description
Fixes #55. The warnings described in the issue were due to a required prop not being passed in. This has been fixed by passing in an empty arrow function as a prop to the UploadPage component in the relevant tests. In these tests the function will never be called hence an arrow function is sufficient. 

## How has this been tested?
Unit tests

## Screenshots
N/A

## Checklist
*(Leave blank if not applicable)*

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
