### PR TITLE
Feature: Global authentication context

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "react-dom": "^17.0.2",
         "react-router-dom": "^6.2.2",
         "react-scripts": "5.0.0",
+        "use-persisted-state": "^0.3.3",
         "web-vitals": "^2.1.4",
         "workbox": "^0.0.0",
         "workbox-core": "^6.5.1",
@@ -4410,6 +4411,14 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@use-it/event-listener": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@use-it/event-listener/-/event-listener-0.1.7.tgz",
+      "integrity": "sha512-hgfExDzUU9uTRTPDCpw2s9jWTxcxmpJya3fK5ADpf5VDpSy8WYwY/kh28XE0tUcbsljeP8wfan48QvAQTSSa3Q==",
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@webassemblyjs/ast": {
@@ -15843,6 +15852,17 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-persisted-state": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/use-persisted-state/-/use-persisted-state-0.3.3.tgz",
+      "integrity": "sha512-pCNlvYC8+XjRxwnIut4teGC9f2p9aD88R8OGseQGZa2dvqG/h1vEGk1vRE1IZG0Vf161UDpn+NlW4+UGubQflQ==",
+      "dependencies": {
+        "@use-it/event-listener": "^0.1.2"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -19836,6 +19856,12 @@
         "@typescript-eslint/types": "5.14.0",
         "eslint-visitor-keys": "^3.0.0"
       }
+    },
+    "@use-it/event-listener": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@use-it/event-listener/-/event-listener-0.1.7.tgz",
+      "integrity": "sha512-hgfExDzUU9uTRTPDCpw2s9jWTxcxmpJya3fK5ADpf5VDpSy8WYwY/kh28XE0tUcbsljeP8wfan48QvAQTSSa3Q==",
+      "requires": {}
     },
     "@webassemblyjs/ast": {
       "version": "1.11.1",
@@ -28058,6 +28084,14 @@
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "requires": {
         "punycode": "^2.1.0"
+      }
+    },
+    "use-persisted-state": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/use-persisted-state/-/use-persisted-state-0.3.3.tgz",
+      "integrity": "sha512-pCNlvYC8+XjRxwnIut4teGC9f2p9aD88R8OGseQGZa2dvqG/h1vEGk1vRE1IZG0Vf161UDpn+NlW4+UGubQflQ==",
+      "requires": {
+        "@use-it/event-listener": "^0.1.2"
       }
     },
     "util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "react-dom": "^17.0.2",
     "react-router-dom": "^6.2.2",
     "react-scripts": "5.0.0",
+    "use-persisted-state": "^0.3.3",
     "web-vitals": "^2.1.4",
     "workbox": "^0.0.0",
     "workbox-core": "^6.5.1",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,14 +3,17 @@ import { ThemeProvider } from '@mui/material';
 import { BrowserRouter } from 'react-router-dom';
 import Routes from './pages/Routes';
 import theme from './components/Theme';
+import { AuthContextProvider } from './context/authContext';
 
 function App() {
   return (
-    <ThemeProvider theme={theme}>
-      <BrowserRouter>
-        <Routes />
-      </BrowserRouter>
-    </ThemeProvider>
+    <AuthContextProvider>
+      <ThemeProvider theme={theme}>
+        <BrowserRouter>
+          <Routes />
+        </BrowserRouter>
+      </ThemeProvider>
+    </AuthContextProvider>
   );
 }
 

--- a/src/context/authContext.jsx
+++ b/src/context/authContext.jsx
@@ -1,0 +1,42 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import createPersistedState from 'use-persisted-state';
+
+const useJwtState = createPersistedState('jwt');
+export const AuthContext = React.createContext({});
+
+export function AuthContextProvider({ children }) {
+  const [jwt, setJwt] = useJwtState();
+  const [authenticated, setAuthenticated] = useState(false);
+
+  function logout() {
+    setJwt('');
+  }
+
+  useEffect(async () => {
+    if (jwt === '') {
+      setAuthenticated(false);
+      return;
+    }
+
+    const response = await fetch(`${process.env.API_HOST}:${process.env.API_PORT}/login`, {
+      method: 'GET',
+      headers: new Headers({
+        Authorization: jwt,
+      }),
+    });
+
+    if (response.ok) {
+      setAuthenticated(true);
+      return;
+    }
+
+    /*
+    If the server determines that the currently stored JWT is invalid, then we are resetting the
+    current state - there's no point in persisting the invalid token.
+    */
+    setJwt('');
+  }, [jwt]);
+
+  const context = useMemo(() => ({ setJwt, authenticated, logout }), [authenticated]);
+  return <AuthContext.Provider value={context}>{children}</AuthContext.Provider>;
+}

--- a/src/context/authContext.jsx
+++ b/src/context/authContext.jsx
@@ -28,7 +28,7 @@ export function AuthContextProvider({ children }) {
     }
 
     // Triggering a backend call to verify the integrity of the current JWT.
-    const response = await fetch(`${process.env.API_HOST}:${process.env.API_PORT}/login`, {
+    const response = await fetch(`${process.env.API_HOST}:${process.env.API_PORT}/verify`, {
       method: 'GET',
       headers: new Headers({
         Authorization: jwt,

--- a/src/context/authContext.jsx
+++ b/src/context/authContext.jsx
@@ -4,10 +4,19 @@ import createPersistedState from 'use-persisted-state';
 const useJwtState = createPersistedState('jwt');
 export const AuthContext = React.createContext({});
 
+/**
+ * The main application is wrapped around this {@link AuthContextProvider} so that other modules of
+ * the application are able to access properties related to User authentication e.g. current JWT,
+ * authentication status and helper function to log the user out.
+ *
+ * A library called 'use-persisted-state' is being used to store the token in the local storage of
+ * the browser.
+ */
 export function AuthContextProvider({ children }) {
   const [jwt, setJwt] = useJwtState();
   const [authenticated, setAuthenticated] = useState(false);
 
+  // Clears the JWT, which triggers the useEffect() below to set authenticated to false.
   function logout() {
     setJwt('');
   }
@@ -18,6 +27,7 @@ export function AuthContextProvider({ children }) {
       return;
     }
 
+    // Triggering a backend call to verify the integrity of the current JWT.
     const response = await fetch(`${process.env.API_HOST}:${process.env.API_PORT}/login`, {
       method: 'GET',
       headers: new Headers({
@@ -37,6 +47,6 @@ export function AuthContextProvider({ children }) {
     setJwt('');
   }, [jwt]);
 
-  const context = useMemo(() => ({ setJwt, authenticated, logout }), [authenticated]);
+  const context = useMemo(() => ({ jwt, setJwt, authenticated, logout }), [jwt, authenticated]);
   return <AuthContext.Provider value={context}>{children}</AuthContext.Provider>;
 }

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,15 +1,12 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
-import { AuthContextProvider } from './context/authContext';
 import { ServiceWorkerProvider } from './context/serviceWorkerContext';
 
 ReactDOM.render(
   <React.StrictMode>
     <ServiceWorkerProvider>
-      <AuthContextProvider>
-        <App />
-      </AuthContextProvider>
+      <App />
     </ServiceWorkerProvider>
   </React.StrictMode>,
   document.getElementById('root'),

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,12 +1,15 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
+import { AuthContextProvider } from './context/authContext';
 import { ServiceWorkerProvider } from './context/serviceWorkerContext';
 
 ReactDOM.render(
   <React.StrictMode>
     <ServiceWorkerProvider>
-      <App />
+      <AuthContextProvider>
+        <App />
+      </AuthContextProvider>
     </ServiceWorkerProvider>
   </React.StrictMode>,
   document.getElementById('root'),


### PR DESCRIPTION
## Description

The intent of this pull request is to implement a context provider that manages the JWT token within the application. The `<App/>` component is wrapped around this `<AuthContextProvider/>` so that all components within our application can get access to it.

When the application starts up, the context checks whether there is a key in the browser's local storage called 'jwt'. If not, it initializes the key with a value of an empty string. The context also provides a method called `setJwt(string)` which is used to set the JWT to the localStorage when the user signs in successfully.

A `logout(string)` method is also present which basically clears the JWT from the local storage. When a JWT is set to the context, it performs an initial check with the `/verify` endpoint whether it's valid.

Closes #54

## How has this been tested?

Since the component is tightly coupled with dependencies related to the Browser API (e.g. localStorage) and backend API calls, no further unit tests have been written. However, the component was manually tested against a mock API producing either a success/failure code depending on the value of JWT provided.

Note: once the login page is up and running, maybe we can add integration tests to check if it works correctly.

## Screenshots

N/A

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
