### PR TITLE
Feature: Automate request authorization header

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,8 @@
         "@testing-library/jest-dom": "^5.16.2",
         "@testing-library/react": "^12.1.4",
         "@testing-library/user-event": "^13.5.0",
+        "axios": "^0.26.1",
+        "emoji-picker-react": "^3.5.1",
         "history": "^5.3.0",
         "prop-types": "^15.8.1",
         "react": "^17.0.2",
@@ -4980,6 +4982,14 @@
         "node": ">=4"
       }
     },
+    "node_modules/axios": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "dependencies": {
+        "follow-redirects": "^1.14.8"
+      }
+    },
     "node_modules/axobject-query": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
@@ -6857,6 +6867,11 @@
       "funding": {
         "url": "https://github.com/sindresorhus/emittery?sponsor=1"
       }
+    },
+    "node_modules/emoji-picker-react": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/emoji-picker-react/-/emoji-picker-react-3.5.1.tgz",
+      "integrity": "sha512-cuSthFAvUO8Q1N7KJPEgZ7N0JNIWPKgN5GUmKe71UlSD4qFYI/p05RT9nohlWOq6YSFhEy2mI/60zBZiaku4mg=="
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -20321,6 +20336,14 @@
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.1.tgz",
       "integrity": "sha512-gd1kmb21kwNuWr6BQz8fv6GNECPBnUasepcoLbekws23NVBLODdsClRZ+bQ8+9Uomf3Sm3+Vwn0oYG9NvwnJCw=="
     },
+    "axios": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "requires": {
+        "follow-redirects": "^1.14.8"
+      }
+    },
     "axobject-query": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
@@ -21728,6 +21751,11 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.8.1.tgz",
       "integrity": "sha512-uDfvUjVrfGJJhymx/kz6prltenw1u7WrCg1oa94zYY8xxVpLLUu045LAT0dhDZdXG58/EpPL/5kA180fQ/qudg=="
+    },
+    "emoji-picker-react": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/emoji-picker-react/-/emoji-picker-react-3.5.1.tgz",
+      "integrity": "sha512-cuSthFAvUO8Q1N7KJPEgZ7N0JNIWPKgN5GUmKe71UlSD4qFYI/p05RT9nohlWOq6YSFhEy2mI/60zBZiaku4mg=="
     },
     "emoji-regex": {
       "version": "9.2.2",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@testing-library/jest-dom": "^5.16.2",
     "@testing-library/react": "^12.1.4",
     "@testing-library/user-event": "^13.5.0",
+    "axios": "^0.26.1",
     "emoji-picker-react": "^3.5.1",
     "history": "^5.3.0",
     "prop-types": "^15.8.1",


### PR DESCRIPTION
## Description

Axios is now configured within the project such that when a verified JWT is received on the frontend, Axios will be modified globally so that it applies the `Authorization` header to all requests leaving the client after that moment. This will make it much easier for the frontend team to now send requests.

Closes #68

## How has this been tested?

Due to similar reasoning to #54, since this `authContext.js` has a lot of dependencies, it becomes really hard to unit test it. However, I had manually created a mock API using `express` in order to test the `Authorization` headers of the requests being sent out in different scenarios.

Furthermore, since this file will never be modified by anyone except me, I can make sure to run these manual tests each time before pushing any changes (so that no errors are introduced).

## Screenshots

N/A

## Checklist
*(Leave blank if not applicable)*

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
