### PR TITLE
Scaffold Courses Page

### DIFF
--- a/src/components/Timetable/BuddyCard.jsx
+++ b/src/components/Timetable/BuddyCard.jsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import Card from '@mui/material/Card';
+import CardActions from '@mui/material/CardActions';
+import CardContent from '@mui/material/CardContent';
+import Button from '@mui/material/Button';
+import Typography from '@mui/material/Typography';
+import styles from './BuddyCard.module.css';
+
+export default function BuddyCard() {
+  return (
+    <Card className={styles.cardContainer}>
+      <CardContent>
+        <Typography variant="body">You dont have any buddies in this course yet</Typography>
+      </CardContent>
+      <CardActions>
+        <Button size="Large" variant="outlined" className={styles.button}>
+          Find a buddy
+        </Button>
+      </CardActions>
+    </Card>
+  );
+}

--- a/src/components/Timetable/BuddyCard.jsx
+++ b/src/components/Timetable/BuddyCard.jsx
@@ -4,19 +4,50 @@ import CardActions from '@mui/material/CardActions';
 import CardContent from '@mui/material/CardContent';
 import Button from '@mui/material/Button';
 import Typography from '@mui/material/Typography';
+import PropTypes from 'prop-types';
+import AccountCircleRoundedIcon from '@mui/icons-material/AccountCircleRounded';
 import styles from './BuddyCard.module.css';
 
-export default function BuddyCard() {
+/**
+ * This component is intended to be displayed inside the CoursesPageCard and displays the buddy name.
+ * The component takes in two optional props. Conditional rendering of this component is done based
+ * on whether or not the props are passed in.
+ *
+ */
+
+export default function BuddyCard({ buddyName, courseName }) {
+  if (!buddyName) {
+    return (
+      <Card className={styles.cardContainer}>
+        <CardContent>
+          <Typography variant="body">You dont have any buddies in this course yet</Typography>
+        </CardContent>
+        <CardActions>
+          <Button size="Large" variant="outlined" color="inherit" className={styles.button}>
+            Find a buddy
+          </Button>
+        </CardActions>
+      </Card>
+    );
+  }
+
   return (
     <Card className={styles.cardContainer}>
-      <CardContent>
-        <Typography variant="body">You dont have any buddies in this course yet</Typography>
+      <CardContent className={styles.cardContent}>
+        <AccountCircleRoundedIcon />
+        <Typography variant="body">{buddyName}</Typography>
+        <Typography variant="subtitle">Also takes {courseName}</Typography>
       </CardContent>
-      <CardActions>
-        <Button size="Large" variant="outlined" className={styles.button}>
-          Find a buddy
-        </Button>
-      </CardActions>
     </Card>
   );
 }
+
+BuddyCard.propTypes = {
+  buddyName: PropTypes.string,
+  courseName: PropTypes.string,
+};
+
+BuddyCard.defaultProps = {
+  buddyName: '',
+  courseName: '',
+};

--- a/src/components/Timetable/BuddyCard.module.css
+++ b/src/components/Timetable/BuddyCard.module.css
@@ -1,0 +1,13 @@
+.cardContainer {
+  background-color: #c5d3e9;
+  max-width: 250px;
+  align-items: center;
+  justify-content: center;
+  display: flex;
+  flex-direction: column;
+}
+
+.button {
+  color: black;
+  border-color: black;
+}

--- a/src/components/Timetable/BuddyCard.module.css
+++ b/src/components/Timetable/BuddyCard.module.css
@@ -6,6 +6,12 @@
   display: flex;
   flex-direction: column;
 }
+.cardContent {
+  align-items: center;
+  justify-content: center;
+  display: flex;
+  flex-direction: column;
+}
 
 .button {
   color: black;

--- a/src/components/Timetable/CoursesPageCard.jsx
+++ b/src/components/Timetable/CoursesPageCard.jsx
@@ -4,6 +4,7 @@ import CardActions from '@mui/material/CardActions';
 import CardContent from '@mui/material/CardContent';
 import Button from '@mui/material/Button';
 import Typography from '@mui/material/Typography';
+import PropTypes from 'prop-types';
 import BuddyCard from './BuddyCard';
 import styles from './CoursesPageCard.module.css';
 
@@ -19,12 +20,12 @@ import styles from './CoursesPageCard.module.css';
  * as required
  */
 
-export default function CoursesPageCard() {
+export default function CoursesPageCard({ buddyName, courseName }) {
   return (
     <Card className={styles.cardContainer}>
       <CardContent className={styles.cardContent}>
-        <Typography variant="h5">Softeng750</Typography>
-        <BuddyCard buddyName="Example idk" courseName="SE750" />
+        <Typography variant="h5">{courseName}</Typography>
+        <BuddyCard buddyName={buddyName} courseName={courseName} />
       </CardContent>
       <CardActions>
         <Button size="Large" color="warning" variant="outlined" className={styles.button}>
@@ -34,3 +35,12 @@ export default function CoursesPageCard() {
     </Card>
   );
 }
+
+CoursesPageCard.propTypes = {
+  buddyName: PropTypes.string,
+  courseName: PropTypes.string.isRequired,
+};
+
+CoursesPageCard.defaultProps = {
+  buddyName: '',
+};

--- a/src/components/Timetable/CoursesPageCard.jsx
+++ b/src/components/Timetable/CoursesPageCard.jsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+import Card from '@mui/material/Card';
+import CardActions from '@mui/material/CardActions';
+import CardContent from '@mui/material/CardContent';
+import Button from '@mui/material/Button';
+import Typography from '@mui/material/Typography';
+import BuddyCard from './BuddyCard';
+import styles from './CoursesPageCard.module.css';
+
+export default function CoursesPageCard() {
+  return (
+    <Card className={styles.cardContainer}>
+      <CardContent className={styles.cardContent}>
+        <Typography variant="h5">Softeng750</Typography>
+        <BuddyCard />
+      </CardContent>
+      <CardActions>
+        <Button size="Large" color="warning" variant="outlined" className={styles.button}>
+          Remove Course
+        </Button>
+      </CardActions>
+    </Card>
+  );
+}

--- a/src/components/Timetable/CoursesPageCard.jsx
+++ b/src/components/Timetable/CoursesPageCard.jsx
@@ -7,12 +7,24 @@ import Typography from '@mui/material/Typography';
 import BuddyCard from './BuddyCard';
 import styles from './CoursesPageCard.module.css';
 
+/**
+ * This component can display one courses card on the timetable page. It is intended to be displayed
+ *  after timetable upload. The child component buddy card can be instantiated as required to
+ *  display the buddy details for the course. See BuddyCard.jsx for more details
+ *
+ * TODO:
+ * Currently this component only displays a single buddy card, with a course name and buddy name.
+ * This needs to be extended to take in a list of course names and their corresponding buddies in
+ * that course. The map function can be used to then map these props to the buddy card component
+ * as required
+ */
+
 export default function CoursesPageCard() {
   return (
     <Card className={styles.cardContainer}>
       <CardContent className={styles.cardContent}>
         <Typography variant="h5">Softeng750</Typography>
-        <BuddyCard />
+        <BuddyCard buddyName="Example idk" courseName="SE750" />
       </CardContent>
       <CardActions>
         <Button size="Large" color="warning" variant="outlined" className={styles.button}>

--- a/src/components/Timetable/CoursesPageCard.module.css
+++ b/src/components/Timetable/CoursesPageCard.module.css
@@ -4,6 +4,7 @@
   align-items: center;
   display: flex;
   flex-direction: column;
+  justify-content: space-between;
 }
 
 .cardContent {

--- a/src/components/Timetable/CoursesPageCard.module.css
+++ b/src/components/Timetable/CoursesPageCard.module.css
@@ -1,0 +1,18 @@
+.cardContainer {
+  max-width: fit-content;
+  min-height: 500px;
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+}
+
+.cardContent {
+  align-items: center;
+  justify-content: center;
+  display: flex;
+  flex-direction: column;
+}
+
+.button {
+  border-color: red;
+}

--- a/src/components/Timetable/__tests__/BuddyCard.test.jsx
+++ b/src/components/Timetable/__tests__/BuddyCard.test.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import BuddyCard from '../BuddyCard';
+
+describe('BuddyCard render with no props', () => {
+  test('should display default text', () => {
+    render(<BuddyCard />);
+
+    expect(screen.getByText(/You dont have any buddies in this course yet/i)).toBeInTheDocument();
+  });
+  test('should display find buddy button', () => {
+    render(<BuddyCard />);
+
+    expect(screen.getByRole('button', { name: /Find a buddy/i })).toBeInTheDocument();
+  });
+});
+
+describe('BuddyCard render with props', () => {
+  test('should display buddy name', () => {
+    render(<BuddyCard buddyName="Example Name" courseName="SE751" />);
+
+    expect(screen.getByText(/Example Name/i)).toBeInTheDocument();
+  });
+  test('should display course name', () => {
+    render(<BuddyCard buddyName="Example Name" courseName="SE751" />);
+
+    expect(screen.getByText(/SE751/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/Timetable/__tests__/CoursesPageCard.test.jsx
+++ b/src/components/Timetable/__tests__/CoursesPageCard.test.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import CoursesPageCard from '../CoursesPageCard';
+
+describe('Render Courses Card with no buddy name props', () => {
+  test('should display Course Title', () => {
+    render(<CoursesPageCard courseName="SE751" />);
+
+    expect(screen.getByText(/SE751/i)).toBeInTheDocument();
+  });
+  test('should display find buddy button', () => {
+    render(<CoursesPageCard courseName="SE751" />);
+
+    expect(screen.getByRole('button', { name: /Find a buddy/i })).toBeInTheDocument();
+  });
+});
+
+describe('Courses Card render with buddy name and course name', () => {
+  test('should display buddy name', () => {
+    render(<CoursesPageCard buddyName="Example Name" courseName="SE751" />);
+
+    expect(screen.getByText(/Example Name/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Description
This PR resolves issue #19 and adds a basic courses card component according to figma designs. The component will conditionally render buddy information depending on if the course being displayed has a buddy or not. This needs to extended in the future to take in list of courses instead of one course. It was discussed with the timetable team and decided that that could be tackled in a later issue

## How has this been tested?
Render tests have been created for the BuddyCard component. These can be run using `npm run test`. The Courses Page Card component has the same functionality so a test has not been provided as it would be redundant.

## Screenshots
![image](https://user-images.githubusercontent.com/62319771/158950571-1e3e9d4c-0407-4e04-8363-ef5050e93cc7.png)
![image](https://user-images.githubusercontent.com/62319771/158950459-e5792aa5-f81f-4687-8b6d-8ffd74786447.png)


## Checklist
*(Leave blank if not applicable)*

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
