### PR TITLE
Fix test warnings

### DIFF
--- a/src/components/DialoguesList/__tests__/DialoguesList.test.jsx
+++ b/src/components/DialoguesList/__tests__/DialoguesList.test.jsx
@@ -5,12 +5,12 @@ import DialoguesList from '../DialoguesList';
 
 const mockMessage = [
   {
-    sender: 'id3333',
+    sender: 3333,
     text: 'random message',
     contentType: 'text',
   },
   {
-    sender: 'id5678',
+    sender: 5678,
     text: 'https://play-lh.googleusercontent.com/zepWGavYYErAIBXFZb6OT14I6b-m4TyaG3yjqZy6Hnsmi64vL3upQ3KUsV6Wnsm-e9M=w512',
     contentType: 'image',
   },
@@ -25,7 +25,7 @@ describe('DialoguesList', () => {
     render(
       <DialoguesList
         messages={mockMessage}
-        currentUser="id5678"
+        currentUser={5678}
         senderAvatar="https://play-lh.googleusercontent.com/zepWGavYYErAIBXFZb6OT14I6b-m4TyaG3yjqZy6Hnsmi64vL3upQ3KUsV6Wnsm-e9M=w512"
       />,
     );
@@ -36,7 +36,7 @@ describe('DialoguesList', () => {
     render(
       <DialoguesList
         messages={mockMessage}
-        currentUser="id5678"
+        currentUser={5678}
         senderAvatar="https://play-lh.googleusercontent.com/zepWGavYYErAIBXFZb6OT14I6b-m4TyaG3yjqZy6Hnsmi64vL3upQ3KUsV6Wnsm-e9M=w512"
       />,
     );
@@ -51,7 +51,7 @@ describe('DialoguesList', () => {
     render(
       <DialoguesList
         messages={mockMessage}
-        currentUser="id5678"
+        currentUser={5678}
         senderAvatar="https://play-lh.googleusercontent.com/zepWGavYYErAIBXFZb6OT14I6b-m4TyaG3yjqZy6Hnsmi64vL3upQ3KUsV6Wnsm-e9M=w512"
       />,
     );
@@ -65,7 +65,7 @@ describe('DialoguesList', () => {
       .create(
         <DialoguesList
           messages={mockMessage}
-          currentUser="id5678"
+          currentUser={5678}
           senderAvatar="https://play-lh.googleusercontent.com/zepWGavYYErAIBXFZb6OT14I6b-m4TyaG3yjqZy6Hnsmi64vL3upQ3KUsV6Wnsm-e9M=w512"
         />,
       )

--- a/src/components/DialoguesList/__tests__/__snapshots__/DialoguesList.test.jsx.snap
+++ b/src/components/DialoguesList/__tests__/__snapshots__/DialoguesList.test.jsx.snap
@@ -9,7 +9,7 @@ exports[`DialoguesList produces correct snapshot of multiple messages 1`] = `
       className="MuiAvatar-root MuiAvatar-circular css-1u8q9pb-MuiAvatar-root"
     >
       <img
-        alt="id3333-image"
+        alt="3333-image"
         className="MuiAvatar-img css-1pqm26d-MuiAvatar-img"
         src="https://play-lh.googleusercontent.com/zepWGavYYErAIBXFZb6OT14I6b-m4TyaG3yjqZy6Hnsmi64vL3upQ3KUsV6Wnsm-e9M=w512"
       />


### PR DESCRIPTION
## Description
Fixes issue #78 

Edited the dialogues list test to use a number as the currentUser prop instead of a string. This matches the expected prop type by dialogues list and gets rid of the warning.

## How has this been tested?
Tested using npm test which no longer shows any warnings.

## Screenshots
N/A

## Checklist
*(Leave blank if not applicable)*

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
