### PR TITLE
Upload page styles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
         "@emotion/react": "^11.8.1",

--- a/src/pages/Upload/UploadPage.jsx
+++ b/src/pages/Upload/UploadPage.jsx
@@ -3,12 +3,15 @@ import {
   Button,
   Stack,
   Typography,
-  TextField,
   Link,
   InputAdornment,
-  IconButton,
+  FormControl,
+
+  InputLabel,
+  OutlinedInput,
+
 } from '@mui/material';
-import SendIcon from '@mui/icons-material/Send';
+
 import { useNavigate } from 'react-router-dom';
 import styles from './UploadPage.module.css';
 import { uploadTimetableURL } from '../../api/TimetableAPI';
@@ -43,27 +46,29 @@ export default function UploadPage() {
 
   return (
     <Stack direction="column" spacing={3} className={styles.title}>
-      <Button variant="contained" onClick={handleSubmit}>
-        Upload Timetable
+      <Button variant="contained" onClick={handleSubmit} className={styles.uploadButton}>
+        <b className={styles.textColour}>Upload Timetable ICS File</b>
       </Button>
-      <Typography>OR</Typography>
-      <TextField
-        id="outlined-input"
-        aria-label="Enter URL"
-        label="Enter your calendar URL"
-        disabled={disable}
-        value={calendarURL}
-        onChange={handleChange}
-        InputProps={{
-          endAdornment: (
+      <Typography><b>OR</b></Typography>
+      <FormControl>
+        <InputLabel><b className={styles.textColour}>Input your timetable URL...</b></InputLabel>
+        <OutlinedInput
+          className={styles.textBox}
+          id="outlined-input"
+          aria-label="Enter URL"
+          disabled={disable}
+          value={calendarURL}
+          onChange={handleChange}
+          endAdornment={
             <InputAdornment position="end">
-              <IconButton edge="end" color="primary" aria-label="submit" onClick={handleSubmit}>
-                <SendIcon />
-              </IconButton>
+              <button type="button" variant="contained" aria-label="submit" onClick={handleSubmit} className={styles.button}>
+                <b className={styles.textColour}>Submit</b>
+              </button>
+
             </InputAdornment>
-          ),
-        }}
-      />
+          }
+        />
+      </FormControl>
       <Link
         href="https://uoacal.auckland.ac.nz/home"
         underline="hover"

--- a/src/pages/Upload/UploadPage.jsx
+++ b/src/pages/Upload/UploadPage.jsx
@@ -6,10 +6,8 @@ import {
   Link,
   InputAdornment,
   FormControl,
-
   InputLabel,
   OutlinedInput,
-
 } from '@mui/material';
 
 import { useNavigate } from 'react-router-dom';
@@ -64,7 +62,6 @@ export default function UploadPage() {
               <button type="button" variant="contained" aria-label="submit" onClick={handleSubmit} className={styles.button}>
                 <b className={styles.textColour}>Submit</b>
               </button>
-
             </InputAdornment>
           }
         />

--- a/src/pages/Upload/UploadPage.module.css
+++ b/src/pages/Upload/UploadPage.module.css
@@ -2,4 +2,28 @@
   display: flex;
   align-items: center;
   text-align: center;
+  margin-top: 50px;
+}
+
+.uploadButton{
+ padding: 10px;
+ padding-left: 20px;
+padding-right: 20px;
+}
+
+.textColour{
+  color: grey;
+}
+
+.textBox{
+  width:500px;
+  border-radius: 30px;
+}
+
+.button{
+  border-radius: 30px;
+  padding: 10px;
+  padding-left: 20px;
+  padding-right: 20px;
+  border-width: 1px;
 }


### PR DESCRIPTION
## Description

Add styling to the Timetable upload page. This issue scope covers only the styling of the component, no additional functionality is required. Fixes issue #20 
Styling based on this image:
![image](https://user-images.githubusercontent.com/68948491/160328557-c2a38e76-f30c-44fa-8a2a-792e26b87a3b.png)


## How has this been tested?
Manually tested locally. Chrome using windows 11.

## Screenshots
<img width="1108" alt="image" src="https://user-images.githubusercontent.com/68948491/160329291-60f5871c-a27b-4098-ae90-8cbcec75e150.png">

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
