### PR TITLE
Added Snackbar when no buddies are found for pair.

### DIFF
--- a/src/pages/Pairing/Pairing.jsx
+++ b/src/pages/Pairing/Pairing.jsx
@@ -1,4 +1,4 @@
-import { Button, Container, Grid, Typography } from '@mui/material';
+import { Button, Container, Grid, Snackbar, Typography } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import React, { useContext, useEffect, useState } from 'react';
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
@@ -35,6 +35,7 @@ function Pairing() {
     sharedCourses: [],
     buddyNumber: 0,
   });
+  const [openNoBuddyFoundSnackbar, setOpenNoBuddyFoundSnackbar] = useState(false);
 
   /**
    * If the course is not selected, add to the selectedCourses list.
@@ -62,6 +63,12 @@ function Pairing() {
   const handleFindBuddy = async () => {
     try {
       const pairing = await findPairing(selectedCourses);
+
+      if (pairing.length === 0) {
+        setOpenNoBuddyFoundSnackbar(true);
+        return;
+      }
+
       setBuddies(pairing);
     } catch (err) {
       console.log(err);
@@ -87,6 +94,17 @@ function Pairing() {
       console.error(e);
       setBuddies([]);
     }
+  };
+
+  /**
+   * handleCloseNoBuddyFoundSnackbar to close the snackbar
+   */
+  const handleCloseNoBuddyFoundSnackbar = (event, reason) => {
+    if (reason === 'clickaway') {
+      return;
+    }
+
+    setOpenNoBuddyFoundSnackbar(false);
   };
 
   /**
@@ -144,11 +162,16 @@ function Pairing() {
         <StyledButton
           disabled={numOfSelectedCourses === 0}
           variant="outlined"
-          onClick={() => handleFindBuddy()}
-        >
+          onClick={() => handleFindBuddy()}>
           <Typography color="primaryDark">FIND MY BUDDY</Typography>
           <ArrowForwardIcon />
         </StyledButton>
+        <Snackbar
+          open={openNoBuddyFoundSnackbar}
+          autoHideDuration={3000}
+          onClose={handleCloseNoBuddyFoundSnackbar}
+          message="No buddy found. Please ensure you have selected at least one course."
+        />
       </Grid>
     </Grid>
   );
@@ -180,8 +203,7 @@ function Pairing() {
                 col={4}
                 key={courseId}
                 className={styles.card}
-                onClick={() => handleSelectedCourse(courseId)}
-              >
+                onClick={() => handleSelectedCourse(courseId)}>
                 <CourseCard
                   key={courseId}
                   courseName={name}


### PR DESCRIPTION
## Description
When no buddies has been found from the pairing process initiated by "FIND MY BUDDY" button on the Find Matches page, it now displays a snackbar pop up at the bottom left corner of the screen displaying "No buddy found. Please ensure you have selected at least one course."

Fixes #133 

## How has this been tested?
It has been tested manually. Not sure if this is a bug (it probably is) but if you click on a tiny space between courses in Find Matches page, it actually increments the selected courses number by 1. Doing so, you can test the scenario where "a course is selected" but no buddies are returned.

## Screenshots
<img width="500" alt="Screenshot 2022-03-29 오후 6 59 11" src="https://user-images.githubusercontent.com/68981068/160543472-e5256d08-01ef-42da-ac8b-0020aaf4f15c.png">
<img width="532" alt="Screenshot 2022-03-29 오후 7 01 35" src="https://user-images.githubusercontent.com/68981068/160543803-52649ed6-3c23-43a6-9547-46cb9c4beb9e.png">


## Checklist
*(Leave blank if not applicable)*

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
