### PR TITLE
Redo of the upload styles since it was overwritten

### DIFF
--- a/src/pages/Upload/UploadPage.jsx
+++ b/src/pages/Upload/UploadPage.jsx
@@ -75,9 +75,19 @@ export default function UploadPage() {
           onChange={handleChange}
           endAdornment={
             <InputAdornment position="end">
-              <button type="button" variant="contained" aria-label="submit" onClick={handleSubmit} className={styles.button}>
-                <b className={styles.textColour}>Submit</b>
-              </button>
+              <Button
+                variant="contained"
+                aria-label="submit"
+                onClick={handleSubmit}
+                sx={{
+                  borderRadius: '30px',
+                  padding: '10px',
+                  paddingLeft: '20px',
+                  paddingRight: '20px',
+                  borderWidth: '1px',
+                }}> 
+                  <b className={styles.textColour}>Submit</b>
+                </Button>
             </InputAdornment>
           }
         />

--- a/src/pages/Upload/UploadPage.jsx
+++ b/src/pages/Upload/UploadPage.jsx
@@ -3,12 +3,12 @@ import {
   Button,
   Stack,
   Typography,
-  TextField,
   Link,
   InputAdornment,
-  IconButton,
+  FormControl,
+  InputLabel,
+  OutlinedInput,
 } from '@mui/material';
-import SendIcon from '@mui/icons-material/Send';
 import { useNavigate } from 'react-router-dom';
 import styles from './UploadPage.module.css';
 import { uploadTimetableURL } from '../../api/TimetableAPI';
@@ -58,29 +58,31 @@ export default function UploadPage() {
   };
   return (
     <Stack direction="column" spacing={3} className={styles.title}>
-      <Button variant="contained" onClick={handleClickOpen}>
-        Upload Timetable
+      <Button variant="contained" onClick={handleClickOpen} className={styles.uploadButton}>
+        <b className={styles.textColour}>Upload Timetable ICS File</b>
       </Button>
 
       <UploadPopUp open={open} close={handleClose} />
-      <Typography>OR</Typography>
-      <TextField
-        id="outlined-input"
-        aria-label="Enter URL"
-        label="Enter your calendar URL"
-        disabled={disable}
-        value={calendarURL}
-        onChange={handleChange}
-        InputProps={{
-          endAdornment: (
+      <Typography><b>OR</b></Typography>
+      <FormControl>
+        <InputLabel><b className={styles.textColour}>Input your timetable URL...</b></InputLabel>
+        <OutlinedInput
+          className={styles.textBox}
+          id="outlined-input"
+          aria-label="Enter URL"
+          disabled={disable}
+          value={calendarURL}
+          onChange={handleChange}
+          endAdornment={
             <InputAdornment position="end">
-              <IconButton edge="end" color="primary" aria-label="submit" onClick={handleSubmit}>
-                <SendIcon />
-              </IconButton>
+              <button type="button" variant="contained" aria-label="submit" onClick={handleSubmit} className={styles.button}>
+                <b className={styles.textColour}>Submit</b>
+              </button>
             </InputAdornment>
-          ),
-        }}
-      />
+          }
+        />
+      </FormControl>
+
       <Link
         href="https://uoacal.auckland.ac.nz/home"
         underline="hover"

--- a/src/pages/Upload/UploadPage.module.css
+++ b/src/pages/Upload/UploadPage.module.css
@@ -20,10 +20,3 @@ padding-right: 20px;
   border-radius: 30px !important;
 }
 
-.button{
-  border-radius: 30px;
-  padding: 10px;
-  padding-left: 20px;
-  padding-right: 20px;
-  border-width: 1px;
-}

--- a/src/pages/Upload/UploadPage.module.css
+++ b/src/pages/Upload/UploadPage.module.css
@@ -17,7 +17,7 @@ padding-right: 20px;
 
 .textBox{
   width:500px;
-  border-radius: 30px;
+  border-radius: 30px !important;
 }
 
 .button{


### PR DESCRIPTION
## Description
Redo of the upload page styles since it was overwritten in a merge. For issue #20 

## How has this been tested?
Manually tested locally. Chrome using windows 11.

## Screenshots
<img width="1068" alt="image" src="https://user-images.githubusercontent.com/68948491/161354372-01c4254b-0c3d-4e52-86c8-c34496ec69b7.png">

## Checklist


- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
