### PR TITLE
Fix CI workflow

### DIFF
--- a/.github/workflows/react_testing.yml
+++ b/.github/workflows/react_testing.yml
@@ -1,10 +1,16 @@
 # workflow name
 name: React Testing
 
-# execute on events
+# Events that trigger the workflow
 on:
+  # This workflow is run when changes are pushed to any branch
+  push:
+
+  # This workflow is run when pull requests to any branch are opened, reopened, and synchronized
   pull_request:
-    branches: [ main ]
+
+  # This workflow is run when manually triggered on the GitHub website
+  workflow_dispatch:
 
 # jobs to run
 jobs:


### PR DESCRIPTION
## Description
<!-- *Please include a summary of the change and which issue number is fixed (e.g. Fixes #1). Please also include relevant motivation and context.* -->

Fixes Issue #145 

The CI workflow for GitHub actions has not been running in pull requests when merging to the a2-main branch. The a2-main branch is now the default branch and all pull requests are expected to be merged there for at least the remainder of the second assignment. 

Furthremore, it is better to have the CI workflow for GitHub actions to be triggered for execution in all of the desired cases. 

This pull request adds workflow triggers for all push, pull request and manual workflow dispatch events as there should be no conflict between events and it is better to know the state of each change before, during and after pull requests.

## How has this been tested?
<!-- *Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.* -->

It has been tested locally. The fix is for a GitHub action workflow so there is no new testing. One test case if failing, but this is from an unrelated change in a different pull request is there is an existing Issue #144 for this.

**UPDATE**: Issue #144 has been fixed.

## Checklist
*(Leave blank if not applicable)*

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
