### PR TITLE
Make the gap between course cards unclickable.

### DIFF
--- a/src/components/CourseCard/CourseCard.jsx
+++ b/src/components/CourseCard/CourseCard.jsx
@@ -42,7 +42,7 @@ const StyledCard = styled(Card)(() => ({
   borderRadius: '15px',
 }));
 
-function CourseCard({ courseName, semesterNumber, numbOfStudents, numOfBuddies }) {
+function CourseCard({ courseName, semesterNumber, numbOfStudents, numOfBuddies, onClick }) {
   const [selected, setSelected] = useState(false);
 
   const cardContent = (
@@ -63,8 +63,7 @@ function CourseCard({ courseName, semesterNumber, numbOfStudents, numOfBuddies }
         direction="row"
         alignItems="baseline"
         spacing={1}
-        className={styles.memberNBuddiesText}
-      >
+        className={styles.memberNBuddiesText}>
         <Grid item>
           <Grid container direction="column">
             <Grid item>
@@ -108,7 +107,7 @@ function CourseCard({ courseName, semesterNumber, numbOfStudents, numOfBuddies }
   );
 
   return (
-    <Box className={styles.root}>
+    <Box className={styles.root} onClick={onClick}>
       {selected ? (
         <Box className={styles.root} onClick={() => setSelected(!selected)}>
           <SelectedCard className={styles.card}>

--- a/src/pages/Pairing/Pairing.jsx
+++ b/src/pages/Pairing/Pairing.jsx
@@ -208,16 +208,9 @@ function Pairing() {
         <Grid item>
           <Grid container>
             {courses.map(({ courseId, name, semester, studentCount, buddyCount }) => (
-              <Grid
-                item
-                xs={12}
-                sm={6}
-                md={3}
-                col={4}
-                key={courseId}
-                className={styles.card}
-                onClick={() => handleSelectedCourse(courseId)}>
+              <Grid item xs={12} sm={6} md={3} col={4} key={courseId} className={styles.card}>
                 <CourseCard
+                  onClick={() => handleSelectedCourse(courseId)}
                   key={courseId}
                   courseName={name}
                   semesterNumber={semester}


### PR DESCRIPTION
## Description
Fixes the bug where the gap between two course cards in the pairing page was clickable and would increment the selected course number. 

Closes #151 

## How has this been tested?
Manual Testing

## Screenshots
<!-- *Provide screenshots of what has been implemented. Leave blank if not applicable* -->

## Checklist
<!-- *(Leave blank if not applicable)* -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
